### PR TITLE
Implement working gameplay + minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# mvcMinefields
+team proj team 6

--- a/src/mineField/MineCell.java
+++ b/src/mineField/MineCell.java
@@ -33,12 +33,23 @@ public class MineCell {
         return point.x == mineField.getGridViewSize() - 1 && point.y == mineField.getGridViewSize() - 1;
     }
 
+    public boolean isCurrentCell(Point point) {
+      return point == mineField.getCurrentPosition();
+    }
+
     public void draw(Graphics2D gc) {
         gc.fillRect(xc, yc, size, size);
 
         gc.setColor(Color.BLACK);
+        
+        if (isCurrentCell(point)) {
+            gc.setColor(Color.WHITE);
+        }
         if (isDestinationCell(point)) {
             gc.setColor(Color.GREEN);
+        }
+        if (isCurrentCell(point) && mineField.isAMine(point)) {
+            gc.setColor(Color.WHITE);
         }
         gc.drawRect(xc, yc, size, size);
         gc.setColor(Color.BLACK);
@@ -49,6 +60,5 @@ public class MineCell {
             gc.drawString("?", xc + size / 3, yc + (2 * size) / 3);
         }
     }
-
 
 }

--- a/src/mineField/MineCell.java
+++ b/src/mineField/MineCell.java
@@ -43,7 +43,7 @@ public class MineCell {
         gc.drawRect(xc, yc, size, size);
         gc.setColor(Color.BLACK);
         String count = String.valueOf(mineField.getNumNeighboringMines(point));
-        if (mineField.showSolution() && !mineField.isAMine(point)) {
+        if ((mineField.showSolution() || mineField.isReached(point)) && !mineField.isAMine(point)) {
             gc.drawString(count, xc + size / 3, yc + (2 * size) / 3);
         } else {
             gc.drawString("?", xc + size / 3, yc + (2 * size) / 3);

--- a/src/mineField/MineField.java
+++ b/src/mineField/MineField.java
@@ -24,12 +24,12 @@ public class MineField extends Model {
     private List<Point> path = new ArrayList<>();
 
     private boolean showMineCount = false; // DEBUG: flip to true to debug
-    private final boolean showMineSolution = false;
+    private boolean showMineSolution = true;
 
     private final Color color = Color.GRAY;
     private final Color mineColor = Color.RED;
-    private final Color pathColor = Color.WHITE;
-    private final Color currentPositionColor = Color.CYAN;
+    private final Color pathColor = Color.LIGHT_GRAY;
+    private final Color currentPositionColor = Color.LIGHT_GRAY;
 
     public boolean showSolution() {
         return showMineCount;
@@ -162,8 +162,18 @@ public class MineField extends Model {
 
     public void seedMines() {
         mines.clear();
+
+        Point edgeCase1 = new Point(0, 0);
+        Point edgeCase2 = new Point(19, 19);
         for (int i = 0; i < mineAmount; i++) {
             mines.add(seedMine());
+        }
+
+        if (mines.contains(edgeCase1)) {
+            mines.remove(edgeCase1);
+        }
+        if (mines.contains(edgeCase2)) {
+            mines.remove(edgeCase2);
         }
     }
 
@@ -213,7 +223,10 @@ public class MineField extends Model {
             done = true;
             throw new DestinationReachedException("Destination reached, you won!");
         }
-        path.add(new Point(currentPosition));
+
+        if (!isAMine(currentPosition)) {
+            path.add(new Point(currentPosition));
+        }
         changed();
     }
 
@@ -230,11 +243,14 @@ public class MineField extends Model {
     public class IsAMineException extends Exception {
         public IsAMineException(String message) {
             super(message);
+            showMineSolution = true;
+            // changed();
         }
     }
     public class DestinationReachedException extends Exception {
         public DestinationReachedException(String message) {
             super(message);
+            showMineSolution = true;
         }
     }
 }

--- a/src/mineField/MineField.java
+++ b/src/mineField/MineField.java
@@ -4,7 +4,9 @@ import mvc.Model;
 import mvc.Utilities;
 
 import java.awt.*;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
@@ -19,15 +21,15 @@ public class MineField extends Model {
 
     private final int mineAmount = gridViewSize * gridViewSize * percentMined / 100;
     private Set<Point> mines = new HashSet<>(mineAmount);
+    private List<Point> path = new ArrayList<>();
 
-
-    private boolean showMineCount = true; // DEBUG: flip to true to debug
-    private final boolean showMineSolution = true;
-
+    private boolean showMineCount = false; // DEBUG: flip to true to debug
+    private final boolean showMineSolution = false;
 
     private final Color color = Color.GRAY;
     private final Color mineColor = Color.RED;
-
+    private final Color pathColor = Color.WHITE;
+    private final Color currentPositionColor = Color.CYAN;
 
     public boolean showSolution() {
         return showMineCount;
@@ -42,6 +44,14 @@ public class MineField extends Model {
         return mineColor;
     }
 
+    public Color getPathColor() {
+        return pathColor;
+    }
+
+    public Color getCurrentPositionColor() {
+        return currentPositionColor;
+    }
+
     public int getGridViewSize() {
         return gridViewSize;
     }
@@ -50,13 +60,25 @@ public class MineField extends Model {
         return mines;
     }
 
+    public List<Point> getPath() {
+        return path;
+    }
+    public Point getCurrentPosition() {
+        return currentPosition;
+    }
+
     public MineField() {
         super();
         seedMines();
+        path.add(new Point(0, 0));
     }
 
     public boolean isAMine(Point point) {
         return mines.contains(point);
+    }
+
+    public boolean isReached(Point point) {
+        return path.contains(point);
     }
 
     public int getNumNeighboringMines(Point current) {
@@ -191,6 +213,7 @@ public class MineField extends Model {
             done = true;
             throw new DestinationReachedException("Destination reached, you won!");
         }
+        path.add(new Point(currentPosition));
         changed();
     }
 

--- a/src/mineField/MineField.java
+++ b/src/mineField/MineField.java
@@ -24,7 +24,7 @@ public class MineField extends Model {
     private List<Point> path = new ArrayList<>();
 
     private boolean showMineCount = false; // DEBUG: flip to true to debug
-    private boolean showMineSolution = true;
+    private boolean showMineSolution = false;
 
     private final Color color = Color.GRAY;
     private final Color mineColor = Color.RED;

--- a/src/mineField/MineFieldFactory.java
+++ b/src/mineField/MineFieldFactory.java
@@ -14,20 +14,20 @@ public class MineFieldFactory implements AppFactory {
 
     @Override
     public String[] getEditCommands() {
-        return new String[]{"Northwest", "North", "Northeast", "West", "East", "Southwest", "South", "Southeast"};
+        return new String[]{"NW", "N", "NE", "W", "E", "SW", "S", "SE"};
     }
 
     @Override
     public String getHelp() {
         return
-                "Northwest: Move northwest\n" +
-                        "North: Move north\n" +
-                        "Northeast: Move northeast\n" +
-                        "West: Move west\n" +
-                        "East: Move east\n" +
-                        "Southwest: Move southwest\n" +
-                        "South: Move south\n" +
-                        "Southeast: Move southeast\n";
+                "NW: Move northwest\n" +
+                        "N: Move north\n" +
+                        "NE: Move northeast\n" +
+                        "W: Move west\n" +
+                        "E: Move east\n" +
+                        "SW: Move southwest\n" +
+                        "S: Move south\n" +
+                        "SE: Move southeast\n";
     }
 
     @Override

--- a/src/mineField/MineFieldView.java
+++ b/src/mineField/MineFieldView.java
@@ -57,11 +57,11 @@ public class MineFieldView extends View {
 			}
 		}
 	}
-
+  
 	public void drawMines(Graphics gc, Color color) {
 		MineField mineField = (MineField) model;
-		for (Point mineCoordinates : mineField.getMines()) {
-			drawCellAtCoordinates(gc, mineCoordinates, color);
+		for (Point mine : mineField.getMines()) {
+			drawCellAtCoordinates(gc, mine, color);
 		}
 	}
 
@@ -82,15 +82,22 @@ public class MineFieldView extends View {
 		Color mineColor = mineField.getMineColor();
 		Color pathColor = mineField.getPathColor();
 		Color currentPositionColor = mineField.getCurrentPositionColor();
-
-
+		
 		drawMineBoard(gc, cellBaseColor);
 
-		if (mineField.showMineSolution()) {
-			drawMines(gc, mineColor);
-		}
 		drawPath(gc, pathColor);
+
 		drawCellAtCoordinates(gc, mineField.getCurrentPosition(), currentPositionColor);
+
+		if (mineField.showMineSolution()) {
+      Point lastMine = mineField.getCurrentPosition();
+			drawMines(gc, mineColor);
+      if (mineField.getMines().contains(lastMine)) {
+        drawCellAtCoordinates(gc, lastMine, mineColor);
+      } else {
+        drawCellAtCoordinates(gc, lastMine, currentPositionColor);
+      }
+		}
 		// drawCellAtCoordinates(gc, new Point(0, 0), Color.GREEN); // DEBUG: use this
 		// to debug mine cell
 		// drawCellAtCoordinates(gc, new Point(19, 19), Color.GREEN); // DEBUG: use this

--- a/src/mineField/MineFieldView.java
+++ b/src/mineField/MineFieldView.java
@@ -7,75 +7,94 @@ import mvc.View;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
+import java.util.List;
+import java.util.Set;
+
 
 public class MineFieldView extends View {
 
-    private int cellSize;
+	private int cellSize;
 
-    public MineFieldView(MineField mineField) {
-        super(mineField);
-        adjustCellSize();
+	public MineFieldView(MineField mineField) {
+		super(mineField);
+		adjustCellSize();
 
-        // Add a listener to handle component resizing
-        this.addComponentListener(new ComponentAdapter() {
-            @Override
-            public void componentResized(ComponentEvent e) {
-                // Adjust cellSize when the panel is resized
-                adjustCellSize();
-                repaint(); // Trigger a repaint to redraw the grid based on new size
-            }
-        });
-    }
+		// Add a listener to handle component resizing
+		this.addComponentListener(new ComponentAdapter() {
+			@Override
+			public void componentResized(ComponentEvent e) {
+				// Adjust cellSize when the panel is resized
+				adjustCellSize();
+				repaint(); // Trigger a repaint to redraw the grid based on new size
+			}
+		});
+	}
 
-    private void adjustCellSize() {
-        MineField mineField = (MineField) model;
-        int width = getWidth();
-        int height = getHeight();
+	private void adjustCellSize() {
+		MineField mineField = (MineField) model;
+		int width = getWidth();
+		int height = getHeight();
 
-        // Dynamically calculate the new cell size based on the panel size
-        int gridSize = mineField.getGridViewSize();
-        this.cellSize = Math.min(width / gridSize, height / gridSize);
-    }
+		// Dynamically calculate the new cell size based on the panel size
+		int gridSize = mineField.getGridViewSize();
+		this.cellSize = Math.min(width / gridSize, height / gridSize);
+	}
 
-    public void drawCellAtCoordinates(Graphics gc, Point point, Color color) {
-        MineField mineField = (MineField) model;
-        gc.setColor(color);
-        MineCell cell = new MineCell(mineField, point, cellSize);
-        cell.draw((Graphics2D) gc);
-    }
+	public void drawCellAtCoordinates(Graphics gc, Point point, Color color) {
+		MineField mineField = (MineField) model;
+		gc.setColor(color);
+		MineCell cell = new MineCell(mineField, point, cellSize);
+		cell.draw((Graphics2D) gc);
+	}
 
-    public void drawMineBoard(Graphics gc, Color color) {
-        MineField mineField = (MineField) model;
-        int boardSize = mineField.getGridViewSize();
+	public void drawMineBoard(Graphics gc, Color color) {
+		MineField mineField = (MineField) model;
+		int boardSize = mineField.getGridViewSize();
 
-        for (int i = 0; i < boardSize; i++) {
-            for (int j = 0; j < boardSize; j++) {
-                drawCellAtCoordinates(gc, new Point(i, j), color);
-            }
-        }
-    }
+		for (int i = 0; i < boardSize; i++) {
+			for (int j = 0; j < boardSize; j++) {
+				drawCellAtCoordinates(gc, new Point(i, j), color);
+			}
+		}
+	}
 
-    public void drawMines(Graphics gc, Color color) {
-        MineField mineField = (MineField) model;
-        for (Point mineCoordinates : mineField.getMines()) {
-            drawCellAtCoordinates(gc, mineCoordinates, color);
-        }
-    }
+	public void drawMines(Graphics gc, Color color) {
+		MineField mineField = (MineField) model;
+		for (Point mineCoordinates : mineField.getMines()) {
+			drawCellAtCoordinates(gc, mineCoordinates, color);
+		}
+	}
 
-    @Override
-    public void paintComponent(Graphics gc) {
-        super.paintComponent(gc);
-        MineField mineField = (MineField) model;
+	public void drawPath(Graphics gc, Color color) {
+		MineField mineField = (MineField) model;
+		List<Point> path = mineField.getPath();
+		for (Point cellCoordinate : path) {
+			drawCellAtCoordinates(gc, cellCoordinate, color);
+		}
+	}
 
-        Color cellBaseColor = mineField.getColor();
-        Color mineColor = mineField.getMineColor();
-        drawMineBoard(gc, cellBaseColor);
+	@Override
+	public void paintComponent(Graphics gc) {
+		super.paintComponent(gc);
+		MineField mineField = (MineField) model;
 
-        if (mineField.showMineSolution()) {
-            drawMines(gc, mineColor);
-        }
-//        drawCellAtCoordinates(gc, new Point(0, 0), Color.GREEN); // DEBUG: use this to debug mine cell
-//        drawCellAtCoordinates(gc, new Point(19, 19), Color.GREEN); // DEBUG: use this to debug mine cell
+		Color cellBaseColor = mineField.getColor();
+		Color mineColor = mineField.getMineColor();
+		Color pathColor = mineField.getPathColor();
+		Color currentPositionColor = mineField.getCurrentPositionColor();
 
-    }
+
+		drawMineBoard(gc, cellBaseColor);
+
+		if (mineField.showMineSolution()) {
+			drawMines(gc, mineColor);
+		}
+		drawPath(gc, pathColor);
+		drawCellAtCoordinates(gc, mineField.getCurrentPosition(), currentPositionColor);
+		// drawCellAtCoordinates(gc, new Point(0, 0), Color.GREEN); // DEBUG: use this
+		// to debug mine cell
+		// drawCellAtCoordinates(gc, new Point(19, 19), Color.GREEN); // DEBUG: use this
+		// to debug mine cell
+
+	}
 }


### PR DESCRIPTION
This adds the functional gameplay of Minefield, allowing you to move through the cells, see your current position, and the path of all the cells you traversed. Neighboring mined cells are hidden from the player until the player steps on a cell. Exceptions are thrown when:

- The player tries to move off of the grid. (Screen wrapping is not allowed).
- The player steps on a mine.
- The player reaches the goal.
- The player attempts to move after the game has ended.

When the player steps on a mine or reaches the end, all mines are revealed.

Resolves #2 